### PR TITLE
Add docker-compose and demo app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,3 +20,4 @@ include_directories("${FREETYPE_INCLUDE_DIRS}")
 
 # Start you CMakeLists.txt here...
 add_executable(demo demo.cpp)
+target_link_libraries(demo inkview)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,3 +19,4 @@ include_directories("${PB_INCLUDE_DIRECTORIES}")
 include_directories("${FREETYPE_INCLUDE_DIRS}")
 
 # Start you CMakeLists.txt here...
+add_executable(demo demo.cpp)

--- a/README.md
+++ b/README.md
@@ -48,15 +48,32 @@ docker run --rm -it \
 
 This will start a bash where you can run your compilation.
 
-Please check the `CMakeLists-SAMPLE.txt` for a boilerplate
-for your own cmake files. 
-
 ## Build your own image
 
 Run \
 `docker build -t pbdev .`
 
 This will create a docker image `pbdev` locally.
+
+## Building applications
+The provided `CMakeLists.txt` contains an example configuration
+for compiling a "Hello, World!" program.
+
+To compile it, run
+```
+cmake .
+cmake --build .
+```
+
+This will produce the `demo` executable. Place it in the `applications`
+directory of your PocketBook. Then you can launch it from the Applications menu.
+
+## Resources
+The demo program is `demo01` from [pmartin/pocketbook-demo](https://github.com/pmartin/pocketbook-demo).
+Check that repository for more examples.
+
+An old version of the inkview documentation is available at
+[pocketbook-free/InkViewDoc](https://github.com/pocketbook-free/InkViewDoc).
 
 ## Final note
 

--- a/demo.cpp
+++ b/demo.cpp
@@ -1,0 +1,37 @@
+// This file is from https://github.com/pmartin/pocketbook-demo/blob/master/demo01/demo01.cpp
+#include "inkview.h"
+
+static const int kFontSize = 42;
+
+static int main_handler(int event_type, int param_one, int param_two)
+{
+    if (EVT_INIT == event_type) {
+        ifont *font = OpenFont("LiberationSans", kFontSize, 0);
+
+        ClearScreen();
+
+        // Everything here is done to a buffer
+        SetFont(font, BLACK);
+        DrawLine(0, 25, ScreenWidth(), 25, 0x00333333);
+        DrawLine(0, ScreenHeight() - 25, ScreenWidth(), ScreenHeight() - 25, 0x00666666);
+        FillArea(50, 250, ScreenWidth() - 50*2, ScreenHeight() - 250*2, 0x00E0E0E0);
+        FillArea(100, 300, ScreenWidth() - 100*2, ScreenHeight() - 300*2, 0x00A0A0A0);
+        DrawTextRect(0, ScreenHeight()/2 - kFontSize/2, ScreenWidth(), kFontSize, "Hello, world!", ALIGN_CENTER);
+
+        // Copies the buffer to the real screen
+        FullUpdate();
+
+        CloseFont(font);
+    }
+    else if (EVT_KEYPRESS == event_type) {
+        CloseApp();
+    }
+    return 0;
+}
+
+
+int main (int argc, char* argv[])
+{
+    InkViewMain(main_handler);
+    return 0;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-version: '3.8'
-
-services:
-  pb:
-    build: .
-    stdin_open: true
-    tty: true
-    volumes:
-      - .:/project

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+
+services:
+  pb:
+    build: .
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/project


### PR DESCRIPTION
Hi!

Sorry for the noise, but you have issues disabled in this repo. You can enable them in settings.

Big thanks for building a dockerfile!

I would like to contribute a sample hello world application but I can't get it to compile fully.

I added the hello world `demo.cpp` source file and added it into `CMakeLists.txt`

I can run `cmake`
```
# cmake .
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMAKE_FIND_ROOT_PATH=/SDK/usr/arm-obreey-linux-gnueabi/sysroot/
CMAKE_FIND_ROOT_PATH=/SDK/usr/arm-obreey-linux-gnueabi/sysroot/
-- The C compiler identification is Clang 7.0.0
-- The CXX compiler identification is Clang 7.0.0
-- Detecting C compiler ABI info
CMAKE_FIND_ROOT_PATH=/SDK/usr/arm-obreey-linux-gnueabi/sysroot/
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /SDK/usr/bin/arm-obreey-linux-gnueabi-clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
CMAKE_FIND_ROOT_PATH=/SDK/usr/arm-obreey-linux-gnueabi/sysroot/
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /SDK/usr/bin/arm-obreey-linux-gnueabi-clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMAKE_FIND_ROOT_PATH=/SDK/usr/arm-obreey-linux-gnueabi/sysroot/
-- Configuring done
-- Generating done
-- Build files have been written to: /project
```
It seems to finish ok.

Then when I try to build the application it gives me these errors
```
root@1e0b35f5e6f1:/project# cmake --build . -v
/usr/bin/cmake -S/project -B/project --check-build-system CMakeFiles/Makefile.cmake 0
/usr/bin/cmake -E cmake_progress_start /project/CMakeFiles /project//CMakeFiles/progress.marks
/usr/bin/make  -f CMakeFiles/Makefile2 all
make[1]: Entering directory '/project'
/usr/bin/make  -f CMakeFiles/demo.dir/build.make CMakeFiles/demo.dir/depend
make[2]: Entering directory '/project'
cd /project && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /project /project /project /project /project/CMakeFiles/demo.dir/DependInfo.cmake --color=
make[2]: Leaving directory '/project'
/usr/bin/make  -f CMakeFiles/demo.dir/build.make CMakeFiles/demo.dir/build
make[2]: Entering directory '/project'
[ 50%] Building CXX object CMakeFiles/demo.dir/demo.cpp.o
/SDK/usr/bin/arm-obreey-linux-gnueabi-clang++ -DPLATFORM_FC -I/SDK/usr/arm-obreey-linux-gnueabi/sysroot/usr/include/freetype2 -fsigned-char -Werror-return-type -DNDEBUG -O2 -pipe -fomit-frame-pointer -march=armv7-a -mtune=cortex-a8 -mfpu=neon -mfloat-abi=softfp  -MD -MT CMakeFiles/demo.dir/demo.cpp.o -MF CMakeFiles/demo.dir/demo.cpp.o.d -o CMakeFiles/demo.dir/demo.cpp.o -c /project/demo.cpp
[100%] Linking CXX executable build/demo
/usr/bin/cmake -E cmake_link_script CMakeFiles/demo.dir/link.txt --verbose=1
/SDK/usr/bin/arm-obreey-linux-gnueabi-clang++ -fsigned-char -Werror-return-type -DNDEBUG -O2 -pipe -fomit-frame-pointer -march=armv7-a -mtune=cortex-a8 -mfpu=neon -mfloat-abi=softfp  -s CMakeFiles/demo.dir/demo.cpp.o -o build/demo   -L/SDK/usr/arm-obreey-linux-gnueabi/sysroot/usr/local/lib 
CMakeFiles/demo.dir/demo.cpp.o: In function `main':
demo.cpp:(.text+0xc): undefined reference to `InkViewMain'
CMakeFiles/demo.dir/demo.cpp.o: In function `main_handler(int, int, int)':
demo.cpp:(.text+0x40): undefined reference to `OpenFont'
demo.cpp:(.text+0x48): undefined reference to `ClearScreen'
demo.cpp:(.text+0x54): undefined reference to `SetFont'
demo.cpp:(.text+0x58): undefined reference to `ScreenWidth'
demo.cpp:(.text+0x78): undefined reference to `DrawLine'
demo.cpp:(.text+0x7c): undefined reference to `ScreenHeight'
demo.cpp:(.text+0x84): undefined reference to `ScreenWidth'
demo.cpp:(.text+0x8c): undefined reference to `ScreenHeight'
demo.cpp:(.text+0xac): undefined reference to `DrawLine'
demo.cpp:(.text+0xb0): undefined reference to `ScreenWidth'
demo.cpp:(.text+0xb8): undefined reference to `ScreenHeight'
demo.cpp:(.text+0xd8): undefined reference to `FillArea'
demo.cpp:(.text+0xdc): undefined reference to `ScreenWidth'
demo.cpp:(.text+0xe4): undefined reference to `ScreenHeight'
demo.cpp:(.text+0x104): undefined reference to `FillArea'
demo.cpp:(.text+0x108): undefined reference to `ScreenHeight'
demo.cpp:(.text+0x110): undefined reference to `ScreenWidth'
demo.cpp:(.text+0x140): undefined reference to `DrawTextRect'
demo.cpp:(.text+0x144): undefined reference to `FullUpdate'
demo.cpp:(.text+0x14c): undefined reference to `CloseFont'
demo.cpp:(.text+0x154): undefined reference to `CloseApp'
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
CMakeFiles/demo.dir/build.make:96: recipe for target 'build/demo' failed
make[2]: *** [build/demo] Error 1
make[2]: Leaving directory '/project'
CMakeFiles/Makefile2:82: recipe for target 'CMakeFiles/demo.dir/all' failed
make[1]: *** [CMakeFiles/demo.dir/all] Error 2
make[1]: Leaving directory '/project'
Makefile:90: recipe for target 'all' failed
make: *** [all] Error 2
```

As I understand, it can produce the `.o` file (meaning `#include "inkview.h"` is ok) but later it can't link it to `libinkview.so`.

How can I solve this?